### PR TITLE
Added CPF and CNPJ to the Code class

### DIFF
--- a/elizabeth/core/elizabeth.py
+++ b/elizabeth/core/elizabeth.py
@@ -551,6 +551,74 @@ class Code(object):
         """
         return self.custom_code(mask=mask)
 
+    @staticmethod
+    def cpf(with_mask=True):
+        """
+        Get a random CPF (brazilian social security code)
+        :param with_mask: use CPF mask (###.###.###-##) in the return
+        :returns: Random CPF
+        """
+        def get_verifying_digit_cpf(cpf, peso):
+            """
+            Calculates the verifying digit for the cpf
+            :param cpf: list of integers with the cpf
+            :param peso: integer with the weigth for the modulo 11 calcule
+            :returns: the verifying digit for the cpf
+            """
+            soma = 0
+            for index, digit in enumerate(cpf):
+                soma += digit * (peso - index)
+            resto = soma % 11
+            if resto == 0 or resto == 1 or resto >= 11:
+                return 0
+            return 11 - resto
+
+        cpf_without_dv = [randint(0, 9) for _ in range(9)]
+        first_dv = get_verifying_digit_cpf(cpf_without_dv, 10)
+        cpf_without_dv.append(first_dv)
+        second_dv = get_verifying_digit_cpf(cpf_without_dv, 11)
+        cpf_without_dv.append(second_dv)
+        cpf = ''.join([str(i) for i in cpf_without_dv])
+        if with_mask:
+            return cpf[:3] + '.' + cpf[3:6] + '.' + cpf[6:9] + '-' + cpf[9:]
+        return cpf
+
+    @staticmethod
+    def cnpj(with_mask=True):
+        """
+        Get a random cnpj (brazilian social security code)
+        :param with_mask: use cnpj mask (###.###.###-##) in the return
+        :returns: Random cnpj
+        """
+        def get_verifying_digit_cnpj(cnpj, peso):
+            """
+            Calculates the verifying digit for the cnpj
+            :param cnpj: list of integers with the cnpj
+            :param peso: integer with the weigth for the modulo 11 calcule
+            :returns: the verifying digit for the cnpj
+            """
+            soma = 0
+            if peso == 5:
+                peso_list = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+            elif peso == 6:
+                peso_list = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+            for i, _ in enumerate(cnpj):
+                soma += peso_list[i] * cnpj[i]
+            resto = soma % 11
+            if resto < 2:
+                return 0
+            return 11 - resto
+
+        cnpj_without_dv = [randint(0, 9) for _ in range(12)]
+        first_dv = get_verifying_digit_cnpj(cnpj_without_dv, 5)
+        cnpj_without_dv.append(first_dv)
+        second_dv = get_verifying_digit_cnpj(cnpj_without_dv, 6)
+        cnpj_without_dv.append(second_dv)
+        cnpj = ''.join([str(i) for i in cnpj_without_dv])
+        if with_mask:
+            return cnpj[:2] + '.' + cnpj[2:5] + '.' + cnpj[5:8] + '/' + \
+                cnpj[8:12] + '-' + cnpj[12:]
+        return cnpj
 
 class Business(object):
     """

--- a/elizabeth/core/elizabeth.py
+++ b/elizabeth/core/elizabeth.py
@@ -557,6 +557,8 @@ class Code(object):
         Get a random CPF (brazilian social security code)
         :param with_mask: use CPF mask (###.###.###-##) in the return
         :returns: Random CPF
+        :Example:
+            001.137.297-40
         """
         def get_verifying_digit_cpf(cpf, peso):
             """
@@ -589,6 +591,8 @@ class Code(object):
         Get a random cnpj (brazilian social security code)
         :param with_mask: use cnpj mask (###.###.###-##) in the return
         :returns: Random cnpj
+        :Example:
+            77.732.230/0001-70
         """
         def get_verifying_digit_cnpj(cnpj, peso):
             """

--- a/tests/test_data/test_code.py
+++ b/tests/test_data/test_code.py
@@ -60,3 +60,18 @@ class CodeTestCase(DummyCase):
         self.assertEqual(len(cpf_without_mask), 11, cpf_without_mask)
         non_numeric_digits = re.sub('\d', '', cpf_without_mask)
         self.assertEqual('', non_numeric_digits, non_numeric_digits)
+
+    def test_cnpj(self):
+        # test if the cnpj has 14 digits with the mask
+        cnpj_with_mask = self.generic.code.cnpj()
+        self.assertEqual(len(cnpj_with_mask), 18, cnpj_with_mask)
+        # test the mask
+        non_numeric_digits = re.sub('\d', '', cnpj_with_mask)
+        self.assertEqual('../-', non_numeric_digits, non_numeric_digits)
+        self.assertEqual(len(re.sub('\D', '', cnpj_with_mask)),
+                         14, cnpj_with_mask)
+        # test for the cnpj without mask
+        cnpj_without_mask = self.generic.code.cnpj(False)
+        self.assertEqual(len(cnpj_without_mask), 14, cnpj_without_mask)
+        non_numeric_digits = re.sub('\d', '', cnpj_without_mask)
+        self.assertEqual('', non_numeric_digits, non_numeric_digits)

--- a/tests/test_data/test_code.py
+++ b/tests/test_data/test_code.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import re
+
 from tests.test_data import DummyCase
 
 
@@ -43,3 +45,18 @@ class CodeTestCase(DummyCase):
 
         a, b, c = result
         self.assertTrue(a.isalpha() and c.isalpha() and b.isdigit())
+
+    def test_cpf(self):
+        # test if the cpf has 14 digits with the mask
+        cpf_with_mask = self.generic.code.cpf()
+        self.assertEqual(len(cpf_with_mask), 14, cpf_with_mask)
+        # test the mask
+        non_numeric_digits = re.sub('\d', '', cpf_with_mask)
+        self.assertEqual('..-', non_numeric_digits, non_numeric_digits)
+        self.assertEqual(len(re.sub('\D', '', cpf_with_mask)),
+                         11, cpf_with_mask)
+        # test for the cpf without mask
+        cpf_without_mask = self.generic.code.cpf(False)
+        self.assertEqual(len(cpf_without_mask), 11, cpf_without_mask)
+        non_numeric_digits = re.sub('\d', '', cpf_without_mask)
+        self.assertEqual('', non_numeric_digits, non_numeric_digits)


### PR DESCRIPTION
The CPF and CNPJ are codes use for identifying brazilian persons and
companies, since it requires some calculation it cannot be generated
with the custom code

Signed-off-by: Alessandro Martini <alessandrofmartini@gmail.com>