### PR TITLE
Added 'add_provider' to generic provider

### DIFF
--- a/elizabeth/core/elizabeth.py
+++ b/elizabeth/core/elizabeth.py
@@ -8,6 +8,7 @@
 import os
 import sys
 import array
+import inspect
 from datetime import (
     date,
     timedelta,
@@ -2157,6 +2158,12 @@ class Generic(object):
         self.internet = Internet()
         self.transport = Transport()
         self.path = Path()
+
+    def add_provider(self, cls):
+        if inspect.isclass(cls):
+            setattr(self, cls.__name__, cls())
+        else:
+            raise TypeError("Provider must be a class")
 
     # TODO: Refactor all.
     @property

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -45,6 +45,20 @@ class GenericTest(DummyCase):
         result = self.generic.code.isbn()
         self.assertIsNotNone(result)
 
+    def test_add_provider(self):
+        class MyCustomProvider:
+            def say(self):
+                return 'Custom'
+
+            def number(self):
+                return 1
+
+        self.generic.add_provider(MyCustomProvider)
+        self.assertIsNotNone(self.generic.MyCustomProvider.say())
+        self.assertEqual(self.generic.MyCustomProvider.number(), 1)
+        with self.assertRaises(TypeError):
+            self.generic.add_provider(True)
+
 
 class LocaleBase(
     GenericTest, AddressTestCase, BusinessTestCase,


### PR DESCRIPTION
Issue #74

`add_provider()` on Generic adds an instance of the provider class, so a new provider class such as `my_generic.add_provider(SampleProvider)` will let you call `my_generic.SampleProvider.method()` afterwards.

I used the class name to set the attribute, but it could definitely be changed to look for a key variable in the new provider to set the attribute within the generic provider.

Raises TypeError if a class type is not passed.