### PR TITLE
Added check for meta class to set provider name

### DIFF
--- a/elizabeth/core/elizabeth.py
+++ b/elizabeth/core/elizabeth.py
@@ -2161,7 +2161,12 @@ class Generic(object):
 
     def add_provider(self, cls):
         if inspect.isclass(cls):
-            setattr(self, cls.__name__.lower(), cls())
+            if hasattr(cls, 'Meta'):
+                if inspect.isclass(cls.Meta) and hasattr(cls.Meta, 'name'):
+                    name = cls.Meta.name
+            else:
+                name = cls.__name__.lower()
+            setattr(self, name, cls())
         else:
             raise TypeError("Provider must be a class")
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -54,9 +54,12 @@ class GenericTest(DummyCase):
             def number():
                 return 1
 
+            class Meta:
+                name = 'custom_provider'
+
         self.generic.add_provider(CustomProvider)
-        self.assertIsNotNone(self.generic.customprovider.say())
-        self.assertEqual(self.generic.customprovider.number(), 1)
+        self.assertIsNotNone(self.generic.custom_provider.say())
+        self.assertEqual(self.generic.custom_provider.number(), 1)
         with self.assertRaises(TypeError):
             self.generic.add_provider(True)
 


### PR DESCRIPTION
Added the ability to set the provider name via a meta subclass. If the subclass isn't available the name will be set using the standard way (`cls.__name__.lower()`).

Modified the test to use an alternate name to test the functionality.