### PR TITLE
fixed issue with wrong method name in documentation

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -74,9 +74,9 @@ Personal
 	# Output:  ♂
 	gender_symbol = person.gender(symbol=True)
 
-	# Get a random profession.
+	# Get a random occupation.
 	# Output: Programmer
-	profession = person.profession()
+	occupation = person.occupation()
 
 	# Get a random political views.
 	# Output: Liberal


### PR DESCRIPTION
Person.occupation() method was referred to as Person.profession() in examples.