### PR TITLE
Added a option to personal provider to generate a random gender

### DIFF
--- a/elizabeth/core/providers.py
+++ b/elizabeth/core/providers.py
@@ -32,7 +32,8 @@ from string import (
 from elizabeth.utils import (
     pull,
     luhn_checksum,
-    locale_information
+    locale_information,
+    check_gender
 )
 
 # International data for Address() provider.
@@ -969,11 +970,7 @@ class Personal(object):
         :Example:
             John.
         """
-        try:
-            names = self.data['names'][gender]
-        except KeyError:
-            raise WrongArgument('gender must be "female" or "male"')
-
+        names = self.data['names'][check_gender(gender)]
         return choice(names)
 
     def surname(self, gender='female'):
@@ -988,10 +985,7 @@ class Personal(object):
         sep_surnames = ('ru', 'is', 'uk')
 
         if self.locale in sep_surnames:
-            try:
-                return choice(self.data['surnames'][gender])
-            except KeyError:
-                raise WrongArgument('gender must be "female" or "male"')
+            return choice(self.data['surnames'][check_gender(gender)])
 
         return choice(self.data['surnames'])
 
@@ -1005,7 +999,7 @@ class Personal(object):
             PhD.
         """
         try:
-            titles = self.data['title'][gender][title_type]
+            titles = self.data['title'][check_gender(gender)][title_type]
         except KeyError:
             raise WrongArgument('Wrong value of argument.')
 
@@ -1021,7 +1015,7 @@ class Personal(object):
         :Example:
             Johann Wolfgang.
         """
-        gender = gender.lower()
+        gender = check_gender(gender)
 
         fmt = '{1} {0}' if reverse else '{0} {1}'
         return fmt.format(
@@ -1040,10 +1034,7 @@ class Personal(object):
             abby1189.
         """
         data = pull('personal.json', 'en')
-        try:
-            username = choice(data['names'][gender])
-        except KeyError:
-            raise WrongArgument('gender must be "female" or "male"')
+        username = choice(data['names'][check_gender(gender)])
 
         username = '%s%s' % (username, randint(2, 9999))
         return username.lower()
@@ -1091,7 +1082,7 @@ class Personal(object):
         host = domains if domains \
             else EMAIL_DOMAINS
 
-        email = self.username(gender) + choice(host)
+        email = self.username(check_gender(gender)) + choice(host)
         return email
 
     @staticmethod
@@ -1196,7 +1187,7 @@ class Personal(object):
             "medium.com/@{}"
         ]
         url = 'http://' + choice(urls)
-        username = self.username(gender)
+        username = self.username(check_gender(gender))
 
         return url.format(username)
 
@@ -1331,7 +1322,7 @@ class Personal(object):
         separated_locales = ['ru', 'uk']
 
         if self.locale in separated_locales:
-            nations = self.data['nationality'][gender]
+            nations = self.data['nationality'][check_gender(gender)]
             return choice(nations)
 
         return choice(self.data['nationality'])

--- a/elizabeth/utils.py
+++ b/elizabeth/utils.py
@@ -5,8 +5,9 @@ import functools
 import json
 import os.path as path
 import urllib.request as request
+from random import choice
 
-from elizabeth.exceptions import UnsupportedLocale
+from elizabeth.exceptions import UnsupportedLocale, WrongArgument
 from elizabeth.settings import SUPPORTED_LOCALES
 
 __all__ = ['pull', 'download_image' 'locale_information']
@@ -146,3 +147,21 @@ def update_dict(initial, other):
         else:
             initial[key] = other[key]
     return initial
+
+def check_gender(gender):
+    """
+    Check a given gender if it's valid
+    
+    Valid genders are 'male', 'female' and None. If None is given, a gender
+    is randomly choosen.
+
+    :param gender: str or None
+    :return: One of 'male' or 'female'
+    :rtype: str
+    """
+    if gender is None:
+        return choice(['male', 'female'])
+    gender = gender.lower()
+    if gender not in ['male', 'female', None]:
+        raise WrongArgument('gender must be "female", "male" or None but was "%s"' % str(gender))
+    return gender

--- a/elizabeth/utils.py
+++ b/elizabeth/utils.py
@@ -162,6 +162,6 @@ def check_gender(gender):
     if gender is None:
         return choice(['male', 'female'])
     gender = gender.lower()
-    if gender not in ['male', 'female', None]:
-        raise WrongArgument('gender must be "female", "male" or None but was "%s"' % str(gender))
+    if gender not in ['male', 'female']:
+        raise WrongArgument('gender must be "female", "male" or None but was "%s"' % gender)
     return gender

--- a/elizabeth/utils.py
+++ b/elizabeth/utils.py
@@ -151,7 +151,7 @@ def update_dict(initial, other):
 def check_gender(gender):
     """
     Check a given gender if it's valid
-    
+
     Valid genders are 'male', 'female' and None. If None is given, a gender
     is randomly choosen.
 

--- a/tests/test_data/test_personal.py
+++ b/tests/test_data/test_personal.py
@@ -196,6 +196,10 @@ def test_name(generic):
     result = generic.personal.name(gender='male')
     assert result in generic.personal.data['names']['male']
 
+    result = generic.personal.name(gender=None)
+    data = generic.personal.data['names']
+    assert result in data['male'] or result in data['female']
+
     with pytest.raises(WrongArgument):
         generic.personal.name(gender='other')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,5 +91,3 @@ def test_check_gender():
     assert set(cntr) == set(['male', 'female'])
     assert abs(cntr['male'] - cntr['female']) < 100, \
         'check_gender returned unequal distributed data'
-
-    

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import sys
 
-from elizabeth.exceptions import UnsupportedLocale
+from elizabeth.exceptions import UnsupportedLocale, WrongArgument
 from elizabeth.utils import (
     pull, luhn_checksum,
     locale_information, download_image,
@@ -81,13 +81,13 @@ def test_update_dict():
 
 
 def test_check_gender():
-    from collections import Counter
     for gender in ['male', 'female', 'Male', 'Female']:
         assert check_gender(gender) == gender.lower()
 
-    cntr = Counter()
+    seen_values = set()
     for _ in range(1000):
-        cntr[check_gender(None)] += 1
-    assert set(cntr) == set(['male', 'female'])
-    assert abs(cntr['male'] - cntr['female']) < 100, \
-        'check_gender returned unequal distributed data'
+        seen_values.add(check_gender(None))
+    assert seen_values == set(['male', 'female'])
+
+    with pytest.raises(WrongArgument):
+        check_gender('some other arg')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,8 @@ from elizabeth.exceptions import UnsupportedLocale
 from elizabeth.utils import (
     pull, luhn_checksum,
     locale_information, download_image,
-    update_dict
+    update_dict,
+    check_gender
 )
 
 
@@ -77,3 +78,18 @@ def test_update_dict():
 
     result = update_dict(first, third)
     assert "spaniel" not in result['animals']['dogs']
+
+
+def test_check_gender():
+    from collections import Counter
+    for gender in ['male', 'female', 'Male', 'Female']:
+        assert check_gender(gender) == gender.lower()
+
+    cntr = Counter()
+    for _ in range(1000):
+        cntr[check_gender(None)] += 1
+    assert set(cntr) == set(['male', 'female'])
+    assert abs(cntr['male'] - cntr['female']) < 100, \
+        'check_gender returned unequal distributed data'
+
+    


### PR DESCRIPTION
This PR is about issue https://github.com/lk-geimfari/elizabeth/issues/154 and implements a option to generate a gender randomly if `None` is passed to any `gender` parameter on personal data.

Note: In my opinion, `None` should be de default and not `female`. But this would be a change which is not backward compatible and might break some stuff.