### PR TITLE
Fix Polish continent names

### DIFF
--- a/elizabeth/data/pl/address.json
+++ b/elizabeth/data/pl/address.json
@@ -1175,12 +1175,12 @@
 	]
   },
   "continent": [
-	"Afrykę",
-	"Amerykę Południową",
-	"Amerykę Północną",
-	"Antarktydę",
-	"Australię",
-	"Eurazję"
+	"Afryka",
+	"Ameryka Południowa",
+	"Ameryka Północna",
+	"Antarktyda",
+	"Australia",
+	"Eurazja"
   ],
   "state": {
 	"name": [


### PR DESCRIPTION
The Polish continent names were in accusative case for no good reason.
Make them nominative instead.