### PR TITLE
Remove bogus "axis." as Polish address component

### DIFF
--- a/elizabeth/data/pl/address.json
+++ b/elizabeth/data/pl/address.json
@@ -5529,7 +5529,6 @@
 	"suffix": [
 	  "ul.",
 	  "plac",
-	  "axis.",
 	  "park"
 	]
   },


### PR DESCRIPTION
I don't what what *axis.* is supposed to stand for, but we certainly don't use it in Polish addresses.