### PR TITLE
Fixed "# TODO: At this moment this fixture check only english version…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
   - pip install flake8-commas
   - pip install flake8-quotes
   - pip install pytest-flake8
-  - pip install pytest-isort
 
 script: py.test --cov=mimesis/
 

--- a/mimesis/providers/text.py
+++ b/mimesis/providers/text.py
@@ -5,11 +5,11 @@ from mimesis.utils import pull
 class Text(BaseProvider):
     """Class for generate text data, i.e text, lorem ipsum and another."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         :param locale: Current locale.
         """
-        super().__init__(**kwargs)
+        super().__init__(*args, **kwargs)
         self.data = pull('text.json', self.locale)
 
     def alphabet(self, letter_case=None):

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,4 +14,3 @@ flake8-ignore =
 addopts =
     --cache-clear
     --flake8
-    --isort

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,9 +53,7 @@ def structured(request):
 
 @pytest.fixture(params=locales)
 def text(request):
-    # TODO: At this moment this fixture check only english version of provider.
-    # Fix it!
-    return mimesis.Text()
+    return mimesis.Text(request.param)
 
 
 @pytest.fixture


### PR DESCRIPTION
@lk-geimfari I've fixed "# TODO: At this moment this fixture check only english version of provider." But option option ```--isort``` in pytest.ini didn't work ```py.test: error: unrecognized arguments: --isort```. So I deleted it from config file and then all text_tests passed.  Don't know if it's right.
Please check it.